### PR TITLE
Fix code scanning alert no. 2: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -5307,12 +5307,19 @@ read_commands_string(const char *prompt ATTRIBUTE_UNUSED)
 static void
 save_options(const char *file)
 {
+	int fd;
 	FILE *fp;
 	const struct dbg_option *opt;	
 
-	fp = fopen(file, "w");
-	if (fp == NULL)
+	fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (fd == -1)
 		return;
+
+	fp = fdopen(fd, "w");
+	if (fp == NULL) {
+		close(fd);
+		return;
+	}
 
 	for (opt = option_list; opt->name; opt++) {
 		if (opt->str_val != NULL)
@@ -5321,7 +5328,8 @@ save_options(const char *file)
 			fprintf(fp, "option %s = %d\n", opt->name, *(opt->num_val));
 	}
 	fclose(fp);
-	chmod(file, 0600);
+	fchmod(fd, 0600);
+	close(fd);
 }
 
 /* close_all --- close all open files */


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gawk/security/code-scanning/2](https://github.com/cooljeanius/gawk/security/code-scanning/2)

To fix the TOCTOU race condition, we should use the `fchmod` function, which operates on the file descriptor obtained from the `open` function. This ensures that the permissions change is applied to the same file that was opened. We will replace the `fopen` and `fclose` calls with `open` and `close`, and use `fchmod` instead of `chmod`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
